### PR TITLE
chore: Bump to v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blutui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Node.js library for the Blutui API",
   "license": "MIT",
   "keywords": [

--- a/src/blutui.ts
+++ b/src/blutui.ts
@@ -15,7 +15,7 @@ import type {
   PostOptions,
 } from './types'
 
-const VERSION = '0.1.0'
+const VERSION = '0.1.1'
 
 const DEFAULT_HOSTNAME = 'api.blutui.com'
 


### PR DESCRIPTION
This PR bumps the version to `v0.1.1`