### PR TITLE
fix: Use prepublish script to build source

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry = "https://registry.npmjs.com/"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blutui",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Node.js library for the Blutui API",
   "license": "MIT",
   "keywords": [
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "test": "jest",
-    "format": "prettier \"src/**/*.{js,ts}\" --write"
+    "format": "prettier \"src/**/*.{js,ts}\" --write",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/src/blutui.ts
+++ b/src/blutui.ts
@@ -15,7 +15,7 @@ import type {
   PostOptions,
 } from './types'
 
-const VERSION = '0.1.1'
+const VERSION = '0.1.2'
 
 const DEFAULT_HOSTNAME = 'api.blutui.com'
 


### PR DESCRIPTION
This PR adds a `prepublishOnly` script to ensure that the source code is built before being published to NPM. This PR also removes the `.npmrc` file to ensure that the one created by the publish workflow is used instead.