### PR TITLE
feat: Add the ability to use the agency API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
+coverage/
 dist

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,9 @@ const config: Config = {
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   setupFiles: ['./jest.setup.ts'],
+  moduleNameMapper: {
+    '@/(.*)': '<rootDir>/src/$1',
+  },
 }
 
 export default config

--- a/src/agency.ts
+++ b/src/agency.ts
@@ -1,0 +1,12 @@
+import { Blutui } from './blutui'
+
+export class Agency {
+  constructor(
+    public username: string,
+    private readonly blutui: Blutui
+  ) {}
+
+  test() {
+    this.blutui
+  }
+}

--- a/src/agency.ts
+++ b/src/agency.ts
@@ -1,12 +1,51 @@
 import { Blutui } from './blutui'
 
+import { Brand } from './resources/agency'
+import type { GetOptions, PostOptions } from './types'
+
 export class Agency {
+  readonly brand = new Brand(this)
+
   constructor(
     public username: string,
     private readonly blutui: Blutui
   ) {}
 
-  test() {
-    this.blutui
+  async get<Result = any>(path: string, options: GetOptions = {}) {
+    return this.blutui.get<Result>(this.getAgencyPath(path), options)
+  }
+
+  async post<Result = any, Entity = any>(
+    path: string,
+    entity: Entity,
+    options: PostOptions = {}
+  ) {
+    return this.blutui.post<Result, Entity>(
+      this.getAgencyPath(path),
+      entity,
+      options
+    )
+  }
+
+  async patch<Result = any, Entity = any>(
+    path: string,
+    entity: Entity,
+    options: PostOptions = {}
+  ) {
+    return this.blutui.patch<Result, Entity>(
+      this.getAgencyPath(path),
+      entity,
+      options
+    )
+  }
+
+  async delete<Result = any>(path: string, options: PostOptions = {}) {
+    return this.blutui.delete<Result>(this.getAgencyPath(path), options)
+  }
+
+  private getAgencyPath(path: string): string {
+    path = path.startsWith('/') ? path.replace('/', '') : path
+
+    return `/v1/agencies/${this.username}/${path}`
   }
 }

--- a/src/blutui.spec.ts
+++ b/src/blutui.spec.ts
@@ -63,10 +63,10 @@ describe('Blutui', () => {
       it('can create and get a new agency instance', () => {
         const blutui = new Blutui('eyJhbGciOi')
 
-        const fooAgency = blutui.agency('foo')
+        const agency = blutui.agency('foo')
 
-        expect(fooAgency).toBeInstanceOf(Agency)
-        expect(fooAgency.username).toBe('foo')
+        expect(agency).toBeInstanceOf(Agency)
+        expect(agency.username).toBe('foo')
       })
     })
 

--- a/src/blutui.spec.ts
+++ b/src/blutui.spec.ts
@@ -1,8 +1,11 @@
 import fetch from 'jest-fetch-mock'
 import fs from 'fs/promises'
 
+import { Agency } from './agency'
 import { Blutui } from './blutui'
-import { NoAccessTokenProvidedException } from './exceptions'
+import { NoAccessTokenProvidedException, NotFoundException } from './exceptions'
+
+import { fetchOnce } from './utils/testing'
 
 describe('Blutui', () => {
   beforeEach(() => fetch.resetMocks())
@@ -53,6 +56,61 @@ describe('Blutui', () => {
         )
 
         expect(blutui.version).toBe(packageJson.version)
+      })
+    })
+
+    describe('agency', () => {
+      it('can create and get a new agency instance', () => {
+        const blutui = new Blutui('eyJhbGciOi')
+
+        const fooAgency = blutui.agency('foo')
+
+        expect(fooAgency).toBeInstanceOf(Agency)
+        expect(fooAgency.username).toBe('foo')
+      })
+    })
+
+    describe('get', () => {
+      describe('when the API responds with a 404 error', () => {
+        it('throws a NotFoundException', async () => {
+          const message = "The requested resource doesn't exist."
+          const type = 'invalid_request_error'
+          fetchOnce(
+            {
+              message,
+              type,
+            },
+            { status: 404 }
+          )
+
+          const blutui = new Blutui('eyJhbGciOi')
+
+          await expect(blutui.get('/path')).rejects.toStrictEqual(
+            new NotFoundException({ message, type, path: '/path' })
+          )
+        })
+      })
+    })
+
+    describe('post', () => {
+      describe('when the API responds with a 404 error', () => {
+        it('throws a NotFoundException', async () => {
+          const message = "The requested resource doesn't exist."
+          const type = 'invalid_request_error'
+          fetchOnce(
+            {
+              message,
+              type,
+            },
+            { status: 404 }
+          )
+
+          const blutui = new Blutui('eyJhbGciOi')
+
+          await expect(blutui.post('/path', {})).rejects.toStrictEqual(
+            new NotFoundException({ message, type, path: '/path' })
+          )
+        })
       })
     })
   })

--- a/src/blutui.ts
+++ b/src/blutui.ts
@@ -1,21 +1,23 @@
+import { Agency } from './agency'
 import {
+  FetchException,
   GenericServerException,
   NoAccessTokenProvidedException,
+  NotFoundException,
   UnauthorizedException,
 } from './exceptions'
 import { Client } from './utils/client'
 
-import { FetchException } from './exceptions'
 import { User } from './resources'
 
 import type {
   BlutuiOptions,
   BlutuiResponseError,
+  DeleteOptions,
   GetOptions,
+  PatchOptions,
   PostOptions,
 } from './types'
-import { Agency } from './agency'
-import { NotFoundException } from './exceptions/not-found.exception'
 
 const VERSION = '0.1.2'
 
@@ -98,6 +100,37 @@ export class Blutui {
   ): Promise<{ data: Result }> {
     try {
       return await this.client.post<Entity>(path, entity, {
+        params: options.query,
+      })
+    } catch (error) {
+      this.handleFetchError({ path, error })
+
+      throw error
+    }
+  }
+
+  async patch<Result = any, Entity = any>(
+    path: string,
+    entity: Entity,
+    options: PatchOptions = {}
+  ): Promise<{ data: Result }> {
+    try {
+      return this.client.patch<Entity>(path, entity, {
+        params: options.query,
+      })
+    } catch (error) {
+      this.handleFetchError({ path, error })
+
+      throw error
+    }
+  }
+
+  async delete<Result = any>(
+    path: string,
+    options: DeleteOptions = {}
+  ): Promise<{ data: Result }> {
+    try {
+      return await this.client.delete(path, {
         params: options.query,
       })
     } catch (error) {

--- a/src/exceptions/index.ts
+++ b/src/exceptions/index.ts
@@ -1,4 +1,5 @@
 export * from './fetch.exception'
 export * from './generic-server.exception'
 export * from './no-access-token-provided.exception'
+export * from './not-found.exception'
 export * from './unauthorized.exception'

--- a/src/exceptions/not-found.exception.ts
+++ b/src/exceptions/not-found.exception.ts
@@ -1,0 +1,20 @@
+export class NotFoundException extends Error {
+  readonly status = 404
+  readonly name = 'NotFoundException'
+  readonly message: string
+  readonly type?: string
+
+  constructor({
+    message,
+    type,
+    path,
+  }: {
+    message?: string
+    type?: string
+    path: string
+  }) {
+    super()
+    this.type = type
+    this.message = message ?? `The requested path '${path}' could not be found.`
+  }
+}

--- a/src/resources/agency/brand/brand.spec.ts
+++ b/src/resources/agency/brand/brand.spec.ts
@@ -3,6 +3,8 @@ import fetch from 'jest-fetch-mock'
 import { Blutui } from '@/blutui'
 import { fetchOnce, fetchURL } from '@/utils/testing'
 
+import brandFixture from './fixtures/brand.json'
+
 const accessToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
 const blutui = new Blutui(accessToken)
@@ -12,7 +14,7 @@ describe('Brand', () => {
 
   describe('get', () => {
     it('can get the agency brand', async () => {
-      fetchOnce({ object: 'brand' })
+      fetchOnce(brandFixture)
       const brand = await blutui.agency('foo').brand.get()
 
       expect(fetchURL()).toContain('/v1/agencies/foo/brand')
@@ -24,34 +26,28 @@ describe('Brand', () => {
 
   describe('create', () => {
     it('can create a new agency brand', async () => {
-      fetchOnce({
-        id: '9bfdb42b-1bf0-4510-978e-46aa329f8efa',
-        object: 'brand',
-        logo: null,
-        primary_color: '#000000',
-        secondary_color: '#222222',
-      })
+      fetchOnce(brandFixture)
       const brand = await blutui.agency('foo').brand.create({
-        primaryColor: '#000000',
-        secondaryColor: '#222222',
+        primaryColor: '#6227FF',
+        secondaryColor: '#333333',
       })
 
       expect(fetchURL()).toContain('/v1/agencies/foo/brand')
       expect(brand).toMatchObject({
         id: '9bfdb42b-1bf0-4510-978e-46aa329f8efa',
         object: 'brand',
-        logo: null,
-        primaryColor: '#000000',
-        secondaryColor: '#222222',
+        logo: 'https://cdn.blutui.com/uploads/assets/logo/youragency.svg',
+        primaryColor: '#6227FF',
+        secondaryColor: '#333333',
       })
     })
   })
 
   describe('update', () => {
     it('can update an agency brand', async () => {
-      fetchOnce({ object: 'brand' })
+      fetchOnce(brandFixture)
       const brand = await blutui.agency('foo').brand.update({
-        primaryColor: '#000000',
+        primaryColor: '#6227FF',
       })
 
       expect(fetchURL()).toContain('/v1/agencies/foo/brand')

--- a/src/resources/agency/brand/brand.spec.ts
+++ b/src/resources/agency/brand/brand.spec.ts
@@ -24,7 +24,13 @@ describe('Brand', () => {
 
   describe('create', () => {
     it('can create a new agency brand', async () => {
-      fetchOnce({ object: 'brand' })
+      fetchOnce({
+        id: '9bfdb42b-1bf0-4510-978e-46aa329f8efa',
+        object: 'brand',
+        logo: null,
+        primary_color: '#000000',
+        secondary_color: '#222222',
+      })
       const brand = await blutui.agency('foo').brand.create({
         primaryColor: '#000000',
         secondaryColor: '#222222',
@@ -32,7 +38,11 @@ describe('Brand', () => {
 
       expect(fetchURL()).toContain('/v1/agencies/foo/brand')
       expect(brand).toMatchObject({
+        id: '9bfdb42b-1bf0-4510-978e-46aa329f8efa',
         object: 'brand',
+        logo: null,
+        primaryColor: '#000000',
+        secondaryColor: '#222222',
       })
     })
   })

--- a/src/resources/agency/brand/brand.spec.ts
+++ b/src/resources/agency/brand/brand.spec.ts
@@ -1,0 +1,71 @@
+import fetch from 'jest-fetch-mock'
+
+import { Blutui } from '@/blutui'
+import { fetchOnce, fetchURL } from '@/utils/testing'
+
+const accessToken =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
+const blutui = new Blutui(accessToken)
+
+describe('Brand', () => {
+  beforeEach(() => fetch.resetMocks())
+
+  describe('get', () => {
+    it('can get the agency brand', async () => {
+      fetchOnce({ object: 'brand' })
+      const brand = await blutui.agency('foo').brand.get()
+
+      expect(fetchURL()).toContain('/v1/agencies/foo/brand')
+      expect(brand).toMatchObject({
+        object: 'brand',
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('can create a new agency brand', async () => {
+      fetchOnce({ object: 'brand' })
+      const brand = await blutui.agency('foo').brand.create({
+        primaryColor: '#000000',
+        secondaryColor: '#222222',
+      })
+
+      expect(fetchURL()).toContain('/v1/agencies/foo/brand')
+      expect(brand).toMatchObject({
+        object: 'brand',
+      })
+    })
+  })
+
+  describe('update', () => {
+    it('can update an agency brand', async () => {
+      fetchOnce({ object: 'brand' })
+      const brand = await blutui.agency('foo').brand.update({
+        primaryColor: '#000000',
+      })
+
+      expect(fetchURL()).toContain('/v1/agencies/foo/brand')
+      expect(brand).toMatchObject({
+        object: 'brand',
+      })
+    })
+  })
+
+  describe('remove', () => {
+    it('can remove an agency brand', async () => {
+      fetchOnce({
+        id: '9bfdb42b-1bf0-4510-978e-46aa329f8efa',
+        object: 'brand',
+        deleted: true,
+      })
+      const brand = await blutui.agency('foo').brand.remove()
+
+      expect(fetchURL()).toContain('/v1/agencies/foo/brand')
+      expect(brand).toMatchObject({
+        id: '9bfdb42b-1bf0-4510-978e-46aa329f8efa',
+        object: 'brand',
+        deleted: true,
+      })
+    })
+  })
+})

--- a/src/resources/agency/brand/brand.ts
+++ b/src/resources/agency/brand/brand.ts
@@ -7,8 +7,11 @@ import {
   BrandResponse,
   CreateBrandOptions,
   SerializedCreateBrandOptions,
+  SerializedUpdateBrandOptions,
+  UpdateBrandOptions,
   type Brand as BrandI,
 } from './interfaces'
+import { serializeUpdateBrandOptions } from './serializers/update-brand-options.serializer'
 
 export class Brand {
   constructor(private readonly agency: Agency) {}
@@ -28,8 +31,11 @@ export class Brand {
     return deserializeBrand(data)
   }
 
-  async update(payload: {}): Promise<BrandI> {
-    const { data } = await this.agency.patch<BrandResponse>('/brand', payload)
+  async update(payload: UpdateBrandOptions): Promise<BrandI> {
+    const { data } = await this.agency.patch<
+      BrandResponse,
+      SerializedUpdateBrandOptions
+    >('/brand', serializeUpdateBrandOptions(payload))
 
     return deserializeBrand(data)
   }

--- a/src/resources/agency/brand/brand.ts
+++ b/src/resources/agency/brand/brand.ts
@@ -1,0 +1,42 @@
+import { Agency } from '@/agency'
+
+import { deserializeBrand, serializeCreateBrandOptions } from './serializers'
+
+import { DeletedResponse } from '@/types'
+import {
+  BrandResponse,
+  CreateBrandOptions,
+  SerializedCreateBrandOptions,
+  type Brand as BrandI,
+} from './interfaces'
+
+export class Brand {
+  constructor(private readonly agency: Agency) {}
+
+  async get(): Promise<BrandI> {
+    const { data } = await this.agency.get<BrandResponse>('/brand')
+
+    return deserializeBrand(data)
+  }
+
+  async create(payload: CreateBrandOptions): Promise<BrandI> {
+    const { data } = await this.agency.post<
+      BrandResponse,
+      SerializedCreateBrandOptions
+    >('/brand', serializeCreateBrandOptions(payload))
+
+    return deserializeBrand(data)
+  }
+
+  async update(payload: {}): Promise<BrandI> {
+    const { data } = await this.agency.patch<BrandResponse>('/brand', payload)
+
+    return deserializeBrand(data)
+  }
+
+  async remove(): Promise<DeletedResponse> {
+    const { data } = await this.agency.delete<DeletedResponse>('/brand')
+
+    return data
+  }
+}

--- a/src/resources/agency/brand/brand.ts
+++ b/src/resources/agency/brand/brand.ts
@@ -16,12 +16,20 @@ import { serializeUpdateBrandOptions } from './serializers/update-brand-options.
 export class Brand {
   constructor(private readonly agency: Agency) {}
 
+  /**
+   * Get the brand for the current agency.
+   */
   async get(): Promise<BrandI> {
     const { data } = await this.agency.get<BrandResponse>('/brand')
 
     return deserializeBrand(data)
   }
 
+  /**
+   * Create a new brand for the current agency.
+   *
+   * @param payload - The values to create the brand
+   */
   async create(payload: CreateBrandOptions): Promise<BrandI> {
     const { data } = await this.agency.post<
       BrandResponse,
@@ -31,6 +39,11 @@ export class Brand {
     return deserializeBrand(data)
   }
 
+  /**
+   * Update the brand for the current agency.
+   *
+   * @param payload - The values to update the brand
+   */
   async update(payload: UpdateBrandOptions): Promise<BrandI> {
     const { data } = await this.agency.patch<
       BrandResponse,
@@ -40,6 +53,9 @@ export class Brand {
     return deserializeBrand(data)
   }
 
+  /**
+   * Remove the brand for the current agency.
+   */
   async remove(): Promise<DeletedResponse> {
     const { data } = await this.agency.delete<DeletedResponse>('/brand')
 

--- a/src/resources/agency/brand/fixtures/brand.json
+++ b/src/resources/agency/brand/fixtures/brand.json
@@ -1,0 +1,9 @@
+{
+  "id": "9bfdb42b-1bf0-4510-978e-46aa329f8efa",
+  "object": "brand",
+  "logo": "https://cdn.blutui.com/uploads/assets/logo/youragency.svg",
+  "primary_color": "#6227FF",
+  "secondary_color": "#333333",
+  "created_at": 1690330767,
+  "updated_at": 1703633941
+}

--- a/src/resources/agency/brand/interfaces/brand.interface.ts
+++ b/src/resources/agency/brand/interfaces/brand.interface.ts
@@ -1,0 +1,19 @@
+export interface Brand {
+  id: string
+  object: 'brand'
+  logo: string | null
+  primaryColor: string | null
+  secondaryColor: string | null
+  createdAt: number
+  updatedAt: number
+}
+
+export interface BrandResponse {
+  id: string
+  object: 'brand'
+  logo: string | null
+  primary_color: string | null
+  secondary_color: string | null
+  created_at: number
+  updated_at: number
+}

--- a/src/resources/agency/brand/interfaces/create-brand-options.interface.ts
+++ b/src/resources/agency/brand/interfaces/create-brand-options.interface.ts
@@ -1,0 +1,11 @@
+export interface CreateBrandOptions {
+  logo?: string
+  primaryColor: `#${string}`
+  secondaryColor: `#${string}`
+}
+
+export interface SerializedCreateBrandOptions {
+  logo?: string
+  primary_color: `#${string}`
+  secondary_color: `#${string}`
+}

--- a/src/resources/agency/brand/interfaces/index.ts
+++ b/src/resources/agency/brand/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './brand.interface'
 export * from './create-brand-options.interface'
+export * from './update-brand-options.interface'

--- a/src/resources/agency/brand/interfaces/index.ts
+++ b/src/resources/agency/brand/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './brand.interface'
+export * from './create-brand-options.interface'

--- a/src/resources/agency/brand/interfaces/update-brand-options.interface.ts
+++ b/src/resources/agency/brand/interfaces/update-brand-options.interface.ts
@@ -1,0 +1,11 @@
+export interface UpdateBrandOptions {
+  logo?: string
+  primaryColor?: `#${string}`
+  secondaryColor?: `#${string}`
+}
+
+export interface SerializedUpdateBrandOptions {
+  logo?: string
+  primary_color?: `#${string}`
+  secondary_color?: `#${string}`
+}

--- a/src/resources/agency/brand/serializers/brand.serializer.ts
+++ b/src/resources/agency/brand/serializers/brand.serializer.ts
@@ -1,0 +1,11 @@
+import { Brand, BrandResponse } from '../interfaces'
+
+export const deserializeBrand = (brand: BrandResponse): Brand => ({
+  id: brand.id,
+  object: brand.object,
+  logo: brand.logo,
+  primaryColor: brand.primary_color,
+  secondaryColor: brand.secondary_color,
+  createdAt: brand.created_at,
+  updatedAt: brand.updated_at,
+})

--- a/src/resources/agency/brand/serializers/create-brand-options.serializer.ts
+++ b/src/resources/agency/brand/serializers/create-brand-options.serializer.ts
@@ -1,0 +1,9 @@
+import { CreateBrandOptions, SerializedCreateBrandOptions } from '../interfaces'
+
+export const serializeCreateBrandOptions = (
+  options: CreateBrandOptions
+): SerializedCreateBrandOptions => ({
+  logo: options.logo,
+  primary_color: options.primaryColor,
+  secondary_color: options.secondaryColor,
+})

--- a/src/resources/agency/brand/serializers/index.ts
+++ b/src/resources/agency/brand/serializers/index.ts
@@ -1,0 +1,2 @@
+export * from './brand.serializer'
+export * from './create-brand-options.serializer'

--- a/src/resources/agency/brand/serializers/update-brand-options.serializer.ts
+++ b/src/resources/agency/brand/serializers/update-brand-options.serializer.ts
@@ -1,0 +1,9 @@
+import { SerializedUpdateBrandOptions, UpdateBrandOptions } from '../interfaces'
+
+export const serializeUpdateBrandOptions = (
+  options: UpdateBrandOptions
+): SerializedUpdateBrandOptions => ({
+  logo: options.logo,
+  primary_color: options.primaryColor,
+  secondary_color: options.secondaryColor,
+})

--- a/src/resources/agency/domains/domains.ts
+++ b/src/resources/agency/domains/domains.ts
@@ -1,0 +1,1 @@
+export class Domains {}

--- a/src/resources/agency/index.ts
+++ b/src/resources/agency/index.ts
@@ -1,0 +1,1 @@
+export { Brand } from './brand/brand'

--- a/src/resources/user/user.spec.ts
+++ b/src/resources/user/user.spec.ts
@@ -1,7 +1,7 @@
 import fetch from 'jest-fetch-mock'
 
-import { Blutui } from '../../blutui'
-import { fetchOnce, fetchURL } from '../../utils/testing'
+import { Blutui } from '@/blutui'
+import { fetchOnce, fetchURL } from '@/utils/testing'
 
 const accessToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
@@ -14,6 +14,7 @@ describe('User', () => {
     it('can get the current user', async () => {
       fetchOnce({ object: 'user' })
       const user = await blutui.user.get()
+
       expect(fetchURL()).toContain('/v1/user')
       expect(user).toMatchObject({
         object: 'user',
@@ -25,6 +26,7 @@ describe('User', () => {
     it('can get the current users email address', async () => {
       fetchOnce({ object: 'user_email' })
       const email = await blutui.user.email()
+
       expect(fetchURL()).toContain('/v1/user/email')
       expect(email).toMatchObject({
         object: 'user_email',

--- a/src/resources/user/user.ts
+++ b/src/resources/user/user.ts
@@ -1,4 +1,4 @@
-import { Blutui } from '../../blutui'
+import { Blutui } from '@/blutui'
 
 import { deserializeUser, deserializeUserEmail } from './serializers'
 

--- a/src/resources/user/user.ts
+++ b/src/resources/user/user.ts
@@ -12,12 +12,18 @@ import type {
 export class User {
   constructor(private readonly blutui: Blutui) {}
 
+  /**
+   * Get the current user.
+   */
   async get(): Promise<UserI> {
     const { data } = await this.blutui.get<UserResponse>('/v1/user')
 
     return deserializeUser(data)
   }
 
+  /**
+   * Get the current user's email address.
+   */
   async email(): Promise<UserEmail> {
     const { data } = await this.blutui.get<UserEmailResponse>('/v1/user/email')
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,22 @@ export interface PostOptions {
   query?: { [key: string]: any }
 }
 
+export interface PatchOptions {
+  query?: { [key: string]: any }
+}
+
+export interface DeleteOptions {
+  query?: { [key: string]: any }
+}
+
+// Response
+
+export interface DeletedResponse {
+  id: string
+  object: string
+  deleted: boolean
+}
+
 // Response Error
 
 export interface BlutuiResponseError {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,4 +14,5 @@ export interface PostOptions {
 
 export interface BlutuiResponseError {
   message: string
+  type: string
 }

--- a/src/utils/client.spec.ts
+++ b/src/utils/client.spec.ts
@@ -10,21 +10,23 @@ const blutui = new Blutui(accessToken)
 describe('Client', () => {
   beforeEach(() => fetch.resetMocks())
 
-  it('get should always include proper header', async () => {
-    await blutui.get('v1/any')
-    expect(fetchURL()).toContain('/v1/any')
-    expect(fetchHeaders()).toHaveProperty(
-      'Authorization',
-      `Bearer ${accessToken}`
-    )
-  })
+  describe('fetch', () => {
+    it('get should always include proper header', async () => {
+      await blutui.get('v1/any')
+      expect(fetchURL()).toContain('/v1/any')
+      expect(fetchHeaders()).toHaveProperty(
+        'Authorization',
+        `Bearer ${accessToken}`
+      )
+    })
 
-  it('post should always include proper header', async () => {
-    await blutui.post('v1/any', {})
-    expect(fetchURL()).toContain('/v1/any')
-    expect(fetchHeaders()).toHaveProperty(
-      'Authorization',
-      `Bearer ${accessToken}`
-    )
+    it('post should always include proper header', async () => {
+      await blutui.post('v1/any', {})
+      expect(fetchURL()).toContain('/v1/any')
+      expect(fetchHeaders()).toHaveProperty(
+        'Authorization',
+        `Bearer ${accessToken}`
+      )
+    })
   })
 })

--- a/src/utils/client.ts
+++ b/src/utils/client.ts
@@ -31,6 +31,32 @@ export class Client {
     })
   }
 
+  async patch<Entity = any>(
+    path: string,
+    entity: Entity,
+    options: { params?: Record<string, any>; headers?: HeadersInit }
+  ) {
+    const resourceURL = this.getResourceURL(path, options.params)
+
+    return await this.fetch(resourceURL, {
+      method: 'PATCH',
+      headers: options.headers,
+      body: getBody(entity),
+    })
+  }
+
+  async delete(
+    path: string,
+    options: { params?: Record<string, any>; headers?: HeadersInit }
+  ) {
+    const resourceURL = this.getResourceURL(path, options.params)
+
+    return await this.fetch(resourceURL, {
+      method: 'DELETE',
+      headers: options.headers,
+    })
+  }
+
   private getResourceURL(path: string, params?: Record<string, any>) {
     const queryString = params
     const url = new URL(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "outDir": "dist",
     "resolveJsonModule": true,
     "strict": true,
-    "target": "ES6"
+    "target": "ES6",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This PR adds the ability to use the Blutui Agency API using a simple `agency('username')` method:

```ts
import Blutui from 'blutui'

const blutui = new Blutui('eyJhbGciOiJIUzI1NiIsInR5...')

// Get your agency brand
blutui.agency('myAgency').brand.get()

// Create a new brand for your agency
blutui.agency('myAgency').brand.create({ logo: '', primaryColor: '', secondaryColor: '' })

// Update your agency brand
blutui.agency('myAgency').brand.update({ logo: '' })

// Remove your agency brand
blutui.agency('myAgency').brand.remove()
```