### PR TITLE
feat: Add a script to manage version updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "jest",
     "lint": "biome lint --error-on-warnings ./src",
     "format": "biome format --write ./src",
+    "update-version": "node scripts/update-version.js",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
@@ -55,6 +56,6 @@
     "node": ">=18"
   },
   "volta": {
-    "node": "20.12.2"
+    "node": "20.16.0"
   }
 }

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs')
+const path = require('node:path')
+
+const packageJsonPath = path.join(__dirname, '..', 'package.json')
+
+// Get the current version from package.json
+function getPackageJsonVersion() {
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+  return packageJson.version
+}
+
+// Bump the version based on the given version type
+function bumpVersion(currentVersion, type) {
+  const versionParts = currentVersion.split('.').map(Number)
+
+  switch (type) {
+    case '--major':
+      versionParts[0]++
+      versionParts[1] = 0
+      versionParts[2] = 0
+      break
+    case '--minor':
+      versionParts[1]++
+      versionParts[2] = 0
+      break
+    case '--patch':
+      versionParts[2]++
+      break
+    default:
+      throw new Error('Invalid argument. Use --major, --minor, or --patch')
+  }
+
+  return versionParts.join('.')
+}
+
+// The main function
+function main() {
+  const args = process.argv.slice(2)
+  if (args.length !== 1) {
+    console.error(
+      'Please provide exactly one argument: --major, --minor, or --patch'
+    )
+    process.exit(1)
+  }
+
+  const currentVersion = getPackageJsonVersion()
+  const newVersion = bumpVersion(currentVersion, args[0])
+
+  console.log(currentVersion, newVersion)
+}
+
+main()

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -4,6 +4,7 @@ const fs = require('node:fs')
 const path = require('node:path')
 
 const packageJsonPath = path.join(__dirname, '..', 'package.json')
+const blutuiPath = path.join(__dirname, '..', 'src', 'blutui.ts')
 
 // Get the current version from package.json
 function getPackageJsonVersion() {
@@ -35,6 +36,26 @@ function bumpVersion(currentVersion, type) {
   return versionParts.join('.')
 }
 
+// Update the package.json version
+function updatePackageJsonVersion(newVersion) {
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+  packageJson.version = newVersion
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
+}
+
+// Update VERSION constant in blutui.ts
+function updateBlutuiVersion(newVersion) {
+  let blutuiContent = fs.readFileSync(blutuiPath, 'utf-8')
+  const versionRegex = /const VERSION = '([0-9]+\.[0-9]+\.[0-9]+)'/
+
+  blutuiContent = blutuiContent.replace(
+    versionRegex,
+    `const VERSION = '${newVersion}'`
+  )
+
+  fs.writeFileSync(blutuiPath, blutuiContent)
+}
+
 // The main function
 function main() {
   const args = process.argv.slice(2)
@@ -48,7 +69,10 @@ function main() {
   const currentVersion = getPackageJsonVersion()
   const newVersion = bumpVersion(currentVersion, args[0])
 
-  console.log(currentVersion, newVersion)
+  updatePackageJsonVersion(newVersion)
+  updateBlutuiVersion(newVersion)
+
+  console.log(`Version updated to ${newVersion}`)
 }
 
 main()

--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -72,7 +72,7 @@ function main() {
   updatePackageJsonVersion(newVersion)
   updateBlutuiVersion(newVersion)
 
-  console.log(`Version updated to ${newVersion}`)
+  console.log(`Version updated from ${$currentVersion} to ${newVersion}`)
 }
 
 main()


### PR DESCRIPTION
This PR introduces a script `update-version` to handle SDK versioning. Running the `update-version` npm script will automatically apply a change to the appropriate files based on the desired version.

For example the following script will update the appropriate files to create a patch. Version `1.0.0` would become `1.0.1`:

```bash
npm run update-version -- --patch
```

Similarly adding the `--minor` argument would update the version from `1.0.0` to `1.1.0`:

```bash
npm run update-version -- --minor
```

For a major release, adding the `--major` argument would update the version from `1.0.0` to `2.0.0`:

```bash
npm run update-version -- --major
```