### PR TITLE
change: Add chore prefix for all dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,15 @@ updates:
     # Check for updates daily
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   # Enable version updates for Github Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
This PR adds a `chore` prefix to all dependabot PR's