### PR TITLE
chore: Bump to v0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blutui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Node.js library for the Blutui API",
   "license": "MIT",
   "keywords": [

--- a/src/blutui.ts
+++ b/src/blutui.ts
@@ -21,7 +21,7 @@ import type {
   PostOptions,
 } from './types'
 
-const VERSION = '0.7.0'
+const VERSION = '0.8.0'
 
 const DEFAULT_HOSTNAME = 'api.blutui.com'
 


### PR DESCRIPTION
This PR bumps the version from `0.7.0` to `0.8.0`